### PR TITLE
Refactor data augment

### DIFF
--- a/tactus_data/datasets/dataset.py
+++ b/tactus_data/datasets/dataset.py
@@ -9,7 +9,6 @@ from tactus_data.utils import video_to_img
 from tactus_data.utils.retracker import stupid_reid
 from tactus_data.utils.skeletonization import yolov7
 from tactus_data.utils.skeletonization import MODEL_WEIGHTS_PATH
-from tactus_data.utils.data_augment import grid_augment, gridParam
 
 RAW_DIR = Path("data/raw/")
 INTERIM_DIR = Path("data/interim/")
@@ -129,7 +128,7 @@ def _count_files_in_dir(directory: Path, pattern: str):
 
 
 def augment_all_vid(input_folder_path: Path,
-                    grid: gridParam,
+                    grid,
                     fps: int,
                     json_name: str = "yolov7.json",
                     max_copy: int = -1,
@@ -156,13 +155,13 @@ def augment_all_vid(input_folder_path: Path,
                generated
     random_seed : value of the random seed to replicated same training data
     """
-    random.seed(random_seed)
-    total_cpy = 0
-    list_dir = list(input_folder_path.iterdir())
-    list_dir.remove(input_folder_path / "readme.md")
-    for path_dir in tqdm(list_dir):
-        vid_path = Path(path_dir / _fps_folder_name(fps))
-        vid_name = vid_path.glob('**/' + json_name)
-        for injson in vid_name:
-            total_cpy += grid_augment(injson, grid, max_copy)
-    print("Generated ",total_cpy, "copies")
+    # random.seed(random_seed)
+    # total_cpy = 0
+    # list_dir = list(input_folder_path.iterdir())
+    # list_dir.remove(input_folder_path / "readme.md")
+    # for path_dir in tqdm(list_dir):
+    #     vid_path = Path(path_dir / _fps_folder_name(fps))
+    #     vid_name = vid_path.glob('**/' + json_name)
+    #     for injson in vid_name:
+    #         total_cpy += grid_augment(injson, grid, max_copy)
+    # print("Generated ",total_cpy, "copies")

--- a/tactus_data/datasets/ut_interaction.py
+++ b/tactus_data/datasets/ut_interaction.py
@@ -46,6 +46,11 @@ def extract_skeletons(fps: int = 10, device: str = None):
     dataset.extract_skeletons(NAME, dataset.INTERIM_DIR, dataset.PROCESSED_DIR, fps, device)
 
 
+def augment(grid: dict = None, fps: int = 10):
+    """augment all skeletons of ut_interaction"""
+    dataset.augment_all_vid(dataset.PROCESSED_DIR / NAME.name, grid, fps)
+
+
 def download():
     """Download and extract dataset from source"""
     for zip_file_url in DOWNLOAD_URL:

--- a/tactus_data/utils/data_augment.py
+++ b/tactus_data/utils/data_augment.py
@@ -5,19 +5,30 @@ from pathlib import Path
 
 import numpy as np
 import cv2
+from sklearn.model_selection._search import ParameterGrid
 
 from tactus_data.utils.skeletonization import skeleton_bbx
 
 
 DEFAULT_GRID = {
-    "noise": np.linspace(1, 4, 2),
-    "rotation_y": np.concatenate(
-            np.linspace(-20, 20, 3),
-            np.linspace(-160, 200, 3), # flip
-        ),
+    "noise_amplitude": np.linspace(1, 4, 2),
+    "horizontal_flip": [True, False],
+    "rotation_y": np.linspace(-20, 20, 3),
     "rotation_z": np.linspace(-20, 20, 3),
     "rotation_x": np.linspace(-20, 20, 3),
+    "scaling_x": np.linspace(0.8, 1.2, 3),
+    "scaling_y": np.linspace(0.8, 1.2, 3),
 }
+
+
+def _skel_width_height(keypoints: list):
+    """Used by noise_2d(): Returns the max width and height of
+       skeletons keypoints
+    """
+    _, _, width, height = skeleton_bbx(keypoints)
+    xscale = width / 100
+    yscale = height / 100
+    return xscale, yscale
 
 
 def augment_noise_2d(keypoints: list, noise_amplitude: float) -> list:
@@ -45,6 +56,7 @@ def augment_noise_2d(keypoints: list, noise_amplitude: float) -> list:
 
     return keypoints
 
+
 def augment_transform(keypoints: list, transform_mat: np.ndarray) -> list:
     """
     transform a skeleton using a transformation matrix
@@ -66,95 +78,46 @@ def augment_transform(keypoints: list, transform_mat: np.ndarray) -> list:
     return keypoints.flatten()
 
 
+def augment_skeleton(keypoints: list,
+                     matrix: np.ndarray,
+                     noise_amplitude: float = 0,
+                     ) -> list:
+    keypoints = augment_transform(keypoints, matrix)
+    keypoints = augment_noise_2d(keypoints, noise_amplitude)
+
+    return keypoints
 
 
+def transform_matrix_from_grid(
+        resolution,
+        transform_dict: dict = None,
+        horizontal_flip: bool = False,
+        vertical_flip: bool = False,
+        rotation_x: float = 0,
+        rotation_y: float = 0,
+        rotation_z: float = 0,
+        scaling_x: float = 0,
+        scaling_y: float = 0,
+        ) -> np.ndarray:
+    if transform_dict is not None and isinstance(transform_dict, dict):
+        return transform_matrix_from_grid(resolution, **transform_dict)
+
+    h_flip_coef = 1 if horizontal_flip else -1
+    v_flip_coef = 1 if vertical_flip else -1
+
+    return get_transform_matrix(resolution,
+                                (rotation_x, rotation_y, rotation_z),
+                                (h_flip_coef*scaling_x, v_flip_coef*scaling_y, 1))
 
 
-
-class gridParam:
-    """
-    In grid param, each element are a list of parameters, one parameter
-    can be a list if there are multiple values to test. There is an
-    exception for scaling where you just put all the possibilities you want to do
-    """
-
-    def __init__(self, noise=([1], [4]), translation=([0], [0], [0]),
-                 rotation=([0, 20, -20], [0, 180, 30, -30], [0, 10, -10]),
-                 scaling=([1, 1, 1], [1.1, 1, 1], [0.9, 1, 1], [1, 1.1, 1], [1, 0.9, 1])):
-        self.noise = noise
-        self.translation = translation
-        self.rotation = rotation
-        self.scaling = scaling
-
-
-def _skel_width_height(keypoints: list):
-    """Used by noise_2d(): Returns the max width and height of
-       skeletons keypoints
-    """
-    _, _, width, height = skeleton_bbx(keypoints)
-    xscale = width / 100
-    yscale = height / 100
-    return xscale, yscale
-
-
-def noise_2d(input_folder_path: Path,
-             json_name: list[str],
-             output_folder_path: Path,
-             num_copy: int = 3,
-             noise_magnitude: float = 4.0):
-    """
-    Generate 1 json per number of copy asked + the original one. Add
-    randomly add/remove random noise of 1% of the skeleton maximum
-    amplitude to each keypoints coordinates, this 1% max value is
-    multiplied by noise_magnitude
-
-    Parameters
-    ----------
-    input_folder_path : Path,
-                path of the folder where the original json are located
-    json_name : list[str],
-                a list of json files names that are going to be updated
-                Ex: ["file.json"]
-    output_folder_path : Path,
-                  path of the folder where the new generated json are
-                  saved
-    num_copy : int,
-               number of copy to make with slight rotation until it
-               reaches max_angle
-    noise_magnitude : float,
-        coefficient the random noise of maximum 1% of total skeleton amplitude is multiplied by
-    """
-    new_json_name = []
-    for file_name in json_name:
-        with open(str(input_folder_path / file_name)) as file:
-            data = json.load(file)
-            num_frame = len(data['frames'])
-        new_json_name.append(file_name)
-        for copy in range(num_copy):
-            noisy_data = data
-            for frame in range(0, num_frame):
-                for skeleton in range(len(noisy_data['frames'][frame]['skeletons'])):
-                    xscale, yscale = _skel_width_height(noisy_data['frames'][frame]['skeletons'][skeleton]["keypoints"])
-                    for point in range(0, len(noisy_data['frames'][frame]['skeletons'][skeleton]['keypoints']), 3):
-                        # not changing face keypoints
-                        noisy_data['frames'][frame]['skeletons'][skeleton]['keypoints'][point] += (
-                                noise_magnitude * random.random() * xscale * random.choice([-1, 1]))
-                        noisy_data['frames'][frame]['skeletons'][skeleton]['keypoints'][point + 1] += (
-                                noise_magnitude * random.random() * yscale * random.choice([-1, 1]))
-            new_json_name.append(file_name.strip(".json") + "_N" + str(copy) + ".json")
-            with open(str(output_folder_path / new_json_name[len(new_json_name) - 1]),
-                      'w') as outfile:
-                json.dump(noisy_data, outfile)
-    return new_json_name
-
-
-def _get_transform_matrix(resolution: list[int, int],
-                          translation: list,
-                          rotation: list,
-                          scaling: list):
+def get_transform_matrix(resolution: tuple[int, int],
+                         rotation: tuple[float, float, float],
+                         scaling: tuple[float, float, float],
+                         translation: tuple[float, float, float] = None,
+                         ):
     """Create the transform matrix using cartesian dimension"""
     # split input
-    t_x, t_y, t_z = translation
+    t_x, t_y, t_z = translation if translation is not None else (0, 0, 0)
     r_x, r_y, r_z = rotation
     s_x, s_y, s_z = scaling
     # degrees to rad
@@ -215,112 +178,3 @@ def _get_transform_matrix(resolution: list[int, int],
     M_cart = T_M.dot(R_M).dot(S_M)
     M_final = M_fromcart.dot(M_cart).dot(M_tocart)
     return M_final
-
-
-def _cart_augment(M,
-                  original_keypoints: list):
-    """
-    Compute the new keypoints value using the cartesian dimension
-    Matrix
-    """
-    keypoints = []
-    for i in range(0, len(original_keypoints) - 1, 3):
-        keypoints.append([original_keypoints[i], original_keypoints[i + 1]])
-    keypoints = np.array([keypoints], dtype="float")
-    keypoints = cv2.perspectiveTransform(keypoints, M)
-    for i in range(0, len(keypoints[0])):
-        original_keypoints[3 * i] = keypoints[0][i][0].tolist()
-        original_keypoints[3 * i + 1] = keypoints[0][i][1].tolist()
-    return original_keypoints
-
-
-def multiaugment(input_folder_path: Path,
-                 json_name: list[str],
-                 output_folder_path: Path,
-                 translation: list,
-                 rotation: list,
-                 scaling: list):
-    """
-    input_folder_path : Path,
-                path of the folder where the original json are located
-    json_name : list[str],
-                a list of json files names that are going to be updated
-                Ex: ["file.json"]
-    output_folder_path : Path,
-                  path of the folder where the new generated json are
-                  saved
-    translation : list,
-                  list of the parameters for translation matrix
-                  [tx, ty, tz]
-    rotation : list,
-               list of the parameters for rotation matrix [rx, ry, rz]
-    scaling : list,
-              list of the parameters for the scaling matrix
-              [sx, sy, sz]
-    """
-    new_json_name = []
-    for file_name in json_name:
-        with open(str(input_folder_path / file_name)) as file:
-            data = json.load(file)
-            resolution = data["resolution"]
-            num_frame = len(data['frames'])
-        new_data = data
-        for frame in range(0, num_frame):
-            for skeleton in range(len(new_data['frames'][frame]['skeletons'])):
-                new_data['frames'][frame]['skeletons'][skeleton]["keypoints"] = (
-                    _cart_augment(_get_transform_matrix(resolution, translation, rotation, scaling),
-                                  new_data['frames'][frame]['skeletons'][skeleton]["keypoints"]))
-        new_json_name.append(file_name)
-        with open(str(output_folder_path / file_name),
-                  'w') as outfile:
-            json.dump(new_data, outfile)
-    return new_json_name
-
-
-def grid_augment(path_json: Path,
-                 grid: gridParam,
-                 max_copy: int = -1):
-    """
-    Generate multiple json from an original json with different types
-    of augments like translation, rotation, scaling on all 3 axis.
-
-    Parameters
-    ----------
-    path_json : Path,
-                path where the original json file is located
-    grid : gridParam,
-           storing all needed parameters for augments
-    max_copy : int,
-               Maximum copy of an original file that can be
-               generated
-    """
-    parent_folder = path_json.parent
-    choice_rotation = list(product(grid.rotation[0], grid.rotation[1], grid.rotation[2]))
-    choice_translation = list(product(grid.translation[0], grid.translation[1], grid.translation[2]))
-    choice_scaling = grid.scaling
-    choice_noise = list(product(grid.noise[0], grid.noise[1]))
-    generator = product(choice_translation, choice_rotation, choice_scaling, choice_noise)
-    next(generator)  # don't look at original value
-    generated_pic = 0
-    counter = 1
-    if max_copy == -1:
-        flag_limit = False
-    else:
-        flag_limit = True
-    with open(path_json) as file:
-        original_data = json.load(file)
-    for indices in generator:
-        if flag_limit and generated_pic >= max_copy:
-            print("Max copy overflow")
-            break
-        else:
-            # create copy json with final name
-            new_name = path_json.stem + "_augment_" + str(counter) + ".json"
-            with open(str(parent_folder / new_name), 'w') as outfile:
-                json.dump(original_data, outfile)
-            result_multiaugment = multiaugment(parent_folder, [new_name], parent_folder, indices[0], indices[1],
-                                               indices[2])
-            result_noise = noise_2d(parent_folder, result_multiaugment, parent_folder, indices[3][0], indices[3][1])
-            generated_pic += len(result_noise)
-            counter += 1
-    return generated_pic

--- a/tactus_data/utils/data_augment.py
+++ b/tactus_data/utils/data_augment.py
@@ -2,6 +2,7 @@ import json
 import random
 import copy
 from pathlib import Path
+from typing import Union
 
 import numpy as np
 import cv2
@@ -206,7 +207,8 @@ def augment_skeleton(keypoints: list,
     return keypoints.tolist()
 
 
-def grid_augment(formatted_json: Path, grid: dict):
+def grid_augment(formatted_json: Path,
+                 grid: Union[dict[str, list], list[dict[str, list]]]):
     """
     augment a JSON with a grid of parameters. The result files
     are going to be written in the same folder as the original
@@ -216,9 +218,12 @@ def grid_augment(formatted_json: Path, grid: dict):
     ----------
     formatted_json : Path
         the path to the JSON that is going to be augmented
-    grid : dict
-        the grid that is going to be used to generate every
-        combination for the augmentation
+    grid : dict[str, list] | list[dict[str, list]]
+        The parameter grid to explore, as a dictionary mapping estimator
+        parameters to sequences of allowed values.
+        A sequence of dicts signifies a sequence of grids to search, and is
+        useful to avoid exploring parameter combinations that make no sense
+        or have no effect. See the examples below.
     """
     original_data = json.load(formatted_json.open())
     original_stem = formatted_json.stem

--- a/tactus_data/utils/data_augment.py
+++ b/tactus_data/utils/data_augment.py
@@ -79,42 +79,49 @@ def augment_transform(keypoints: list, transform_mat: np.ndarray) -> list:
 
 
 def transform_matrix_from_grid(
-        resolution,
+        resolution: tuple[int, int],
         transform_dict: dict = None,
-        horizontal_flip: bool = False,
-        vertical_flip: bool = False,
-        rotation_x: float = 0,
-        rotation_y: float = 0,
-        rotation_z: float = 0,
-        scale_x: float = 1,
-        scale_y: float = 1,
-        **_
         ) -> np.ndarray:
-    if transform_dict is not None and isinstance(transform_dict, dict):
-        return transform_matrix_from_grid(resolution, **transform_dict)
+    """
+    generate the transformation matrix from a dictionnary
 
-    h_flip_coef = -1 if horizontal_flip else 1
-    v_flip_coef = -1 if vertical_flip else 1
+    Parameters
+    ----------
+    resolution : tuple[int, int]
+        resolution of the incoming frame
+    transform_dict : dict, optional
+        dictionnary to create the matrix from, by default None
+
+    Returns
+    -------
+    np.ndarray
+        transformation matrix
+    """
 
     return get_transform_matrix(resolution,
-                                (rotation_x, rotation_y, rotation_z),
-                                (h_flip_coef*scale_x, v_flip_coef*scale_y, 1))
+                                **transform_dict)
 
 
 def get_transform_matrix(resolution: tuple[int, int],
-                         rotation: tuple[float, float, float],
-                         scaling: tuple[float, float, float],
-                         translation: tuple[float, float, float] = None,
+                         horizontal_flip: bool = False,
+                         vertical_flip: bool = False,
+                         rotation_x: float = 0,
+                         rotation_y: float = 0,
+                         rotation_z: float = 0,
+                         scale_x: float = 1,
+                         scale_y: float = 1,
+                         **_
                          ):
     """Create the transform matrix using cartesian dimension"""
     # split input
-    t_x, t_y, t_z = translation if translation is not None else (0, 0, 0)
-    r_x, r_y, r_z = rotation
-    s_x, s_y, s_z = scaling
+    h_flip_coef = -1 if horizontal_flip else 1
+    v_flip_coef = -1 if vertical_flip else 1
+    t_x, t_y, t_z = (0, 0, 0)
+    s_x, s_y, s_z = (h_flip_coef*scale_x, v_flip_coef*scale_y, 1)
     # degrees to rad
-    theta_rx = np.deg2rad(r_x)
-    theta_ry = np.deg2rad(r_y)
-    theta_rz = np.deg2rad(r_z)
+    theta_rx = np.deg2rad(rotation_x)
+    theta_ry = np.deg2rad(rotation_y)
+    theta_rz = np.deg2rad(rotation_z)
     # sin and cos
     sin_rx, cos_rx = np.sin(theta_rx), np.cos(theta_rx)
     sin_ry, cos_ry = np.sin(theta_ry), np.cos(theta_ry)

--- a/tactus_data/utils/data_augment.py
+++ b/tactus_data/utils/data_augment.py
@@ -7,7 +7,7 @@ import numpy as np
 import cv2
 from sklearn.model_selection._search import ParameterGrid
 
-from tactus_data.utils.skeletonization import skeleton_bbx
+from tactus_data.utils.skeletonization import skeleton_bbx, round_skeleton_kpts
 
 
 DEFAULT_GRID = {
@@ -51,8 +51,8 @@ def augment_noise_2d(keypoints: list, noise_amplitude: float) -> np.ndarray:
     xscale, yscale = _skel_width_height(keypoints)
 
     for i in range(0, len(keypoints), 2):
-        keypoints[i] += noise_amplitude * xscale * (random.random()*2-1)
-        keypoints[i+1] += noise_amplitude * yscale * (random.random()*2-1)
+        keypoints[i] += noise_amplitude * xscale * (random.random() * 2 - 1)
+        keypoints[i + 1] += noise_amplitude * yscale * (random.random() * 2 - 1)
 
     return keypoints
 
@@ -184,6 +184,7 @@ def augment_skeleton(keypoints: list,
                      ) -> list:
     keypoints = augment_transform(keypoints, matrix)
     keypoints = augment_noise_2d(keypoints, noise_amplitude)
+    keypoints = round_skeleton_kpts(keypoints)
 
     return keypoints.tolist()
 
@@ -195,6 +196,8 @@ def grid_augment(formatted_json: Path,
 
     for i, params in enumerate(ParameterGrid(grid)):
         matrix = transform_matrix_from_grid(original_data["resolution"], params)
+
+        noise_amplitude = 0
         if "noise_amplitude" in params:
             noise_amplitude = params["noise_amplitude"]
 

--- a/tactus_data/utils/data_augment.py
+++ b/tactus_data/utils/data_augment.py
@@ -117,7 +117,7 @@ def get_transform_matrix(resolution: tuple[int, int],
     h_flip_coef = -1 if horizontal_flip else 1
     v_flip_coef = -1 if vertical_flip else 1
     t_x, t_y, t_z = (0, 0, 0)
-    s_x, s_y, s_z = (h_flip_coef*scale_x, v_flip_coef*scale_y, 1)
+    s_x, s_y, s_z = (h_flip_coef * scale_x, v_flip_coef * scale_y, 1)
     # degrees to rad
     theta_rx = np.deg2rad(rotation_x)
     theta_ry = np.deg2rad(rotation_y)
@@ -182,6 +182,23 @@ def augment_skeleton(keypoints: list,
                      matrix: np.ndarray,
                      noise_amplitude: float = 0,
                      ) -> list:
+    """
+    augment a single skeleton
+
+    Parameters
+    ----------
+    keypoints : list
+        list of all the skeleton keypoints with only x and y coordinates
+    matrix : np.ndarray
+        transformation matrix of size (3*3)
+    noise_amplitude : float, optional
+        the noise amplitude, by default 0
+
+    Returns
+    -------
+    list
+        the augmented skeleton
+    """
     keypoints = augment_transform(keypoints, matrix)
     keypoints = augment_noise_2d(keypoints, noise_amplitude)
     keypoints = round_skeleton_kpts(keypoints)
@@ -189,8 +206,20 @@ def augment_skeleton(keypoints: list,
     return keypoints.tolist()
 
 
-def grid_augment(formatted_json: Path,
-                 grid: dict):
+def grid_augment(formatted_json: Path, grid: dict):
+    """
+    augment a JSON with a grid of parameters. The result files
+    are going to be written in the same folder as the original
+    file.
+
+    Parameters
+    ----------
+    formatted_json : Path
+        the path to the JSON that is going to be augmented
+    grid : dict
+        the grid that is going to be used to generate every
+        combination for the augmentation
+    """
     original_data = json.load(formatted_json.open())
     original_stem = formatted_json.stem
 

--- a/tactus_data/utils/data_augment.py
+++ b/tactus_data/utils/data_augment.py
@@ -88,6 +88,7 @@ def transform_matrix_from_grid(
         rotation_z: float = 0,
         scale_x: float = 1,
         scale_y: float = 1,
+        **_
         ) -> np.ndarray:
     if transform_dict is not None and isinstance(transform_dict, dict):
         return transform_matrix_from_grid(resolution, **transform_dict)

--- a/tactus_data/utils/data_augment.py
+++ b/tactus_data/utils/data_augment.py
@@ -16,8 +16,8 @@ DEFAULT_GRID = {
     "rotation_y": np.linspace(-20, 20, 3),
     "rotation_z": np.linspace(-20, 20, 3),
     "rotation_x": np.linspace(-20, 20, 3),
-    "scaling_x": np.linspace(0.8, 1.2, 3),
-    "scaling_y": np.linspace(0.8, 1.2, 3),
+    "scale_x": np.linspace(0.8, 1.2, 3),
+    "scale_y": np.linspace(0.8, 1.2, 3),
 }
 
 
@@ -78,16 +78,6 @@ def augment_transform(keypoints: list, transform_mat: np.ndarray) -> list:
     return keypoints.flatten()
 
 
-def augment_skeleton(keypoints: list,
-                     matrix: np.ndarray,
-                     noise_amplitude: float = 0,
-                     ) -> list:
-    keypoints = augment_transform(keypoints, matrix)
-    keypoints = augment_noise_2d(keypoints, noise_amplitude)
-
-    return keypoints
-
-
 def transform_matrix_from_grid(
         resolution,
         transform_dict: dict = None,
@@ -96,18 +86,18 @@ def transform_matrix_from_grid(
         rotation_x: float = 0,
         rotation_y: float = 0,
         rotation_z: float = 0,
-        scaling_x: float = 0,
-        scaling_y: float = 0,
+        scale_x: float = 1,
+        scale_y: float = 1,
         ) -> np.ndarray:
     if transform_dict is not None and isinstance(transform_dict, dict):
         return transform_matrix_from_grid(resolution, **transform_dict)
 
-    h_flip_coef = 1 if horizontal_flip else -1
-    v_flip_coef = 1 if vertical_flip else -1
+    h_flip_coef = -1 if horizontal_flip else 1
+    v_flip_coef = -1 if vertical_flip else 1
 
     return get_transform_matrix(resolution,
                                 (rotation_x, rotation_y, rotation_z),
-                                (h_flip_coef*scaling_x, v_flip_coef*scaling_y, 1))
+                                (h_flip_coef*scale_x, v_flip_coef*scale_y, 1))
 
 
 def get_transform_matrix(resolution: tuple[int, int],
@@ -178,3 +168,13 @@ def get_transform_matrix(resolution: tuple[int, int],
     M_cart = T_M.dot(R_M).dot(S_M)
     M_final = M_fromcart.dot(M_cart).dot(M_tocart)
     return M_final
+
+
+def augment_skeleton(keypoints: list,
+                     matrix: np.ndarray,
+                     noise_amplitude: float = 0,
+                     ) -> list:
+    keypoints = augment_transform(keypoints, matrix)
+    keypoints = augment_noise_2d(keypoints, noise_amplitude)
+
+    return keypoints

--- a/tactus_data/utils/skeletonization.py
+++ b/tactus_data/utils/skeletonization.py
@@ -34,6 +34,7 @@ def yolov7(input_dir: Path, model: Yolov7):
 
     formatted_json["min_nbr_skeletons"] = min_nbr_skeletons
     formatted_json["max_nbr_skeletons"] = max_nbr_skeletons
+    formatted_json["resolution"] = img.shape[:2]
 
     return formatted_json
 


### PR DESCRIPTION
This is going to stay a pull request for the time of the TACTUS-model hyperparameters tuning to be able to quickly improve this branch.

BREAKING CHANGES:
- the class gridParam is no longer used. We are using the same dict as [in sklearn](https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/model_selection/_search.py#L60)
- max_copy parameter no longer exists

OTHER CHANGES
- you can augment only skeletons from ut_interaction with `ut_interaction.augment()`
- readd the `resolution`key to the outputed JSON file
- information about the augmentation are stored in the outputed JSON file
```json
{
    "min_nbr_skeletons": 1,
    "max_nbr_skeletons": 2,
    "resolution": [320, 448],
    "augmentation": {
        "horizontal_flip": true,
        "scale_x": 0.8,
        "scale_y": 1.2
    }
    "frames": [
        {
            "frame_id": "000.jpg",
            "skeletons": [
"..."
```